### PR TITLE
README reorg suggestion; needs 'clang' install on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,22 @@ Demo of bringing up Bluetooth Low Energy (BLE) using Embedded Rust, by turning a
 
 ![controller](./img/gamepad.jpg)
 
+### System libraries
+
+`nrf-sdc` requires clang.
+
+```bash
+# Linux
+sudo apt install llvm clang
+# Windows.
+choco install llvm 
+# Mac
+brew install llvm
+```
+
+
 ## Setup
+
 
 ```bash
 cargo install cargo-binstall # binary installer tool
@@ -24,18 +39,7 @@ cargo run --release
 
 ## Troubleshooting
 
-`nrf-sdc` requires clang.
-
-```bash
-# Linux
-sudo apt install llvm
-# Windows.
-choco install llvm 
-# Mac
-brew install llvm
-```
-
-## Windows
+### Windows
 
 Once installed, you may need to set the LIBCLANG_PATH environment variable to the directory containing libclang.dll.
 


### PR DESCRIPTION
Added `clang` to the necessary Linux installs. I develop on an Ubuntu VM, and mere `llvm` isn't enough. This really is the only important thing; the rest is layout and matter-of-taste. I'd:

- move the library installation steps from after "Setup" to before it. They must be done; otherwise the code won't compile.
- wrapping the windows thingy under `Troubleshooting?` 

   I should probably remove that from the PR since I don't run on Windows.